### PR TITLE
Use common naming for majority-leader-auto-downing spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,9 +131,10 @@ akka.cluster.downing-provider-class = "tanukki.akka.cluster.autodown.MajorityLea
 custom-downing {
   stable-after = 20s
 
-  majority-auto-downing {
+  majority-leader-auto-downing {
     majority-member-role = ""
     down-if-in-minority = true
+    shutdown-actor-system-on-resolution = true
   }
 }
 

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -19,7 +19,7 @@ custom-downing {
     # If set to be false, only cluster will be shutdown and ActorSystem is preserved. Mainly for test purpose.
     shutdown-actor-system-on-resolution = true
   }
-  majority-auto-downing {
+  majority-leader-auto-downing {
     majority-member-role = ""
 
     # Shutdown ActorSystem on split brain resolution.

--- a/src/main/scala/tanukki/akka/cluster/autodown/MajorityLeaderAutoDowning.scala
+++ b/src/main/scala/tanukki/akka/cluster/autodown/MajorityLeaderAutoDowning.scala
@@ -1,6 +1,5 @@
 package tanukki.akka.cluster.autodown
 
-import akka.ConfigurationException
 import akka.actor.{Address, Props, ActorSystem}
 import akka.cluster.{Cluster, DowningProvider}
 import scala.concurrent.Await
@@ -14,7 +13,7 @@ class MajorityLeaderAutoDowning(system: ActorSystem) extends DowningProvider {
   override def downingActorProps: Option[Props] = {
     val stableAfter = system.settings.config.getDuration("custom-downing.stable-after").toMillis millis
     val majorityMemberRole = {
-      val r = system.settings.config.getString("custom-downing.majority-auto-downing.majority-member-role")
+      val r = system.settings.config.getString("custom-downing.majority-leader-auto-downing.majority-member-role")
       if (r.isEmpty) None else Some(r)
     }
     val downIfInMinority = system.settings.config.getBoolean("custom-downing.majority-leader-auto-downing.down-if-in-minority")


### PR DESCRIPTION
Fixes issue https://github.com/TanUkkii007/akka-cluster-custom-downing/issues/11

FYI @TanUkkii007 